### PR TITLE
Update ENS access modifier

### DIFF
--- a/web3swift/Utils/Classes/ENS.swift
+++ b/web3swift/Utils/Classes/ENS.swift
@@ -12,7 +12,7 @@ public struct ENS {
     let web3: web3
     let ensContractAddress: EthereumAddress?
     
-    init(web3: web3) {
+    public init(web3: web3) {
         self.web3 = web3
         switch web3.provider.network {
         case .Mainnet?:


### PR DESCRIPTION
Trying to instantiate an ENS object like so:
```
        let web3 = Web3.InfuraRopstenWeb3()
        let ens = ENS(web3: web3)
```
Results in the following error: `'ENS' initializer is inaccessible due to 'internal' protection level`.

Changing the access modifier to `public` for the `init(web3: web3)` function fixed the problem.

I'm using:
```
Swift 4.2
Xcode 10.0
```