### PR TITLE
Fixed typo in function name

### DIFF
--- a/Sources/web3swift/Web3/Web3+Utils.swift
+++ b/Sources/web3swift/Web3/Web3+Utils.swift
@@ -26,7 +26,7 @@ extension Web3.Utils {
     
     /// Calculate address of deployed contract deterministically based on the address of the deploying Ethereum address
     /// and the nonce of this address
-    public static func calcualteContractAddress(from: EthereumAddress, nonce: BigUInt) -> EthereumAddress? {
+    public static func calculateContractAddress(from: EthereumAddress, nonce: BigUInt) -> EthereumAddress? {
         guard let normalizedAddress = from.addressData.setLengthLeft(32) else {return nil}
         guard let data = RLP.encode([normalizedAddress, nonce] as [AnyObject]) else {return nil}
         guard let contractAddressData = Web3.Utils.sha3(data)?[12..<32] else {return nil}


### PR DESCRIPTION
Was `calcualte...` instead of `calculate...`