### PR TITLE
modified Block struct

### DIFF
--- a/Sources/Web3Core/Structure/Block/Block.swift
+++ b/Sources/Web3Core/Structure/Block/Block.swift
@@ -85,7 +85,12 @@ extension Block: Decodable {
         }
 
         self.difficulty = try container.decodeHex(BigUInt.self, forKey: .difficulty)
-        self.totalDifficulty = (try? container.decodeHex(BigUInt.self, forKey: .totalDifficulty)) ?? .zero
+        if (container.contains(.totalDifficulty)) {
+            // Must throw if value is set but it is invalid
+            self.totalDifficulty = try container.decodeHex(BigUInt.self, forKey: .totalDifficulty)
+        } else {
+            self.totalDifficulty = .zero
+        }
         self.extraData = try container.decodeHex(Data.self, forKey: .extraData)
         self.size = try container.decodeHex(BigUInt.self, forKey: .size)
         self.gasLimit = try container.decodeHex(BigUInt.self, forKey: .gasLimit)

--- a/Sources/Web3Core/Structure/Block/Block.swift
+++ b/Sources/Web3Core/Structure/Block/Block.swift
@@ -85,7 +85,7 @@ extension Block: Decodable {
         }
 
         self.difficulty = try container.decodeHex(BigUInt.self, forKey: .difficulty)
-        self.totalDifficulty = try? container.decodeHex(BigUInt.self, forKey: .totalDifficulty)
+        self.totalDifficulty = (try? container.decodeHex(BigUInt.self, forKey: .totalDifficulty)) ?? .zero
         self.extraData = try container.decodeHex(Data.self, forKey: .extraData)
         self.size = try container.decodeHex(BigUInt.self, forKey: .size)
         self.gasLimit = try container.decodeHex(BigUInt.self, forKey: .gasLimit)

--- a/Sources/Web3Core/Structure/Block/Block.swift
+++ b/Sources/Web3Core/Structure/Block/Block.swift
@@ -24,7 +24,7 @@ public struct Block {
     public var receiptsRoot: Data
     public var miner: EthereumAddress? // MARK: This is NOT optional in web3js
     public var difficulty: BigUInt
-    public var totalDifficulty: BigUInt
+    public var totalDifficulty: BigUInt? // MARK by JoshKim: Removed from Ethereum official Blockschema (https://github.com/ethereum/execution-apis/commit/9e16d5e76a554c733613a2db631130166e2d8725)
     public var extraData: Data
     public var size: BigUInt
     public var gasLimit: BigUInt
@@ -83,7 +83,7 @@ extension Block: Decodable {
         }
 
         self.difficulty = try container.decodeHex(BigUInt.self, forKey: .difficulty)
-        self.totalDifficulty = try container.decodeHex(BigUInt.self, forKey: .totalDifficulty)
+        self.totalDifficulty = try? container.decodeHex(BigUInt.self, forKey: .totalDifficulty)
         self.extraData = try container.decodeHex(Data.self, forKey: .extraData)
         self.size = try container.decodeHex(BigUInt.self, forKey: .size)
         self.gasLimit = try container.decodeHex(BigUInt.self, forKey: .gasLimit)

--- a/Sources/Web3Core/Structure/Block/Block.swift
+++ b/Sources/Web3Core/Structure/Block/Block.swift
@@ -24,7 +24,9 @@ public struct Block {
     public var receiptsRoot: Data
     public var miner: EthereumAddress? // MARK: This is NOT optional in web3js
     public var difficulty: BigUInt
-    public var totalDifficulty: BigUInt? // MARK by JoshKim: Removed from Ethereum official Blockschema (https://github.com/ethereum/execution-apis/commit/9e16d5e76a554c733613a2db631130166e2d8725)
+    /// by JoshKim: Removed from Ethereum official Blockschema making it optional (https://github.com/ethereum/execution-apis/commit/9e16d5e76a554c733613a2db631130166e2d8725)
+    /// If decoding of this field has failed it will be set to 0 to avoid breaking changes. Will be made optional in v4 of web3swift.
+    public var totalDifficulty: BigUInt
     public var extraData: Data
     public var size: BigUInt
     public var gasLimit: BigUInt

--- a/Sources/Web3Core/Structure/Block/Block.swift
+++ b/Sources/Web3Core/Structure/Block/Block.swift
@@ -25,7 +25,7 @@ public struct Block {
     public var miner: EthereumAddress? // MARK: This is NOT optional in web3js
     public var difficulty: BigUInt
     /// by JoshKim: Removed from Ethereum official Blockschema making it optional (https://github.com/ethereum/execution-apis/commit/9e16d5e76a554c733613a2db631130166e2d8725)
-    /// If decoding of this field has failed it will be set to 0 to avoid breaking changes. Will be made optional in v4 of web3swift.
+    /// Set to 0 if not provided. Will be made optional in v4 of web3swift.
     public var totalDifficulty: BigUInt
     public var extraData: Data
     public var size: BigUInt


### PR DESCRIPTION
- modified to allow an optional type of 'totalDifficulty'

- According to 'https://github.com/ethereum/execution-apis/commit/9e16d5e76a554c733613a2db631130166e2d8725', you can see that the 'totalDifficulty field was removed from the Blockschema on September 4.

- Since the existing structure required a 'totalDifficulty' field, if the result of a json structure without a 'totalDifficulty' field is returned from the Ethereum node, there is an issue that decoding fails in the web3swift library. To solve this problem, the 'totalDifficulty' field was changed to an optional field.


## **Summary of Changes**

modified 'totalDifficulty' to optional type in Block struct 


###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
