### PR TITLE
fix: get chain_id with hex strip

### DIFF
--- a/Sources/web3swift/Web3/Web3+HttpProvider.swift
+++ b/Sources/web3swift/Web3/Web3+HttpProvider.swift
@@ -37,7 +37,7 @@ public class Web3HttpProvider: Web3Provider {
             let response: String = try await APIRequest.send(APIRequest.getNetwork.call, parameters: [], with: self).result
             let result: UInt
             if response.hasHexPrefix() {
-                guard let num = BigUInt(response, radix: 16)  else {
+                guard let num = BigUInt(response.stripHexPrefix(), radix: 16)  else {
                     throw Web3Error.processingError(desc: "Get network succeeded but can't be parsed to a valid chain id.")
                 }
                 result = UInt(num)


### PR DESCRIPTION
## **Summary of Changes**

Strip the prefix when casting a hex string to BigUInt

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
