### PR TITLE
fix: Update usages of Data.bytes for compatibility with Swift 6.2

### DIFF
--- a/Sources/Web3Core/KeystoreManager/BIP32HDNode.swift
+++ b/Sources/Web3Core/KeystoreManager/BIP32HDNode.swift
@@ -84,7 +84,7 @@ public class HDNode {
         }
         depth = data[4..<5].bytes[0]
         parentFingerprint = data[5..<9]
-        childNumber = data[9..<13].bytes.withUnsafeBytes { $0.load(as: UInt32.self) }
+        childNumber = Array(data.dropFirst(9).prefix(4)).withUnsafeBytes { $0.load(as: UInt32.self) }
         chaincode = data[13..<45]
         if serializePrivate {
             privateKey = data[46..<78]

--- a/Sources/Web3Core/Utility/Utilities.swift
+++ b/Sources/Web3Core/Utility/Utilities.swift
@@ -239,8 +239,8 @@ public struct Utilities {
     /// Takes a hash of some message. What message is hashed should be checked by user separately.
     public static func hashECRecover(hash: Data, signature: Data) -> EthereumAddress? {
         if signature.count != 65 { return nil }
-        let rData = signature[0..<32].bytes
-        let sData = signature[32..<64].bytes
+        let rData: [UInt8] = Array(signature.prefix(32))
+        let sData: [UInt8] = Array(signature.dropFirst(32).prefix(32))
         var vData = signature[64]
         if vData >= 27 && vData <= 30 {
             vData -= 27
@@ -274,11 +274,11 @@ public struct Utilities {
 
     /// Unmarshals a 65 byte recoverable EC signature into internal structure.
     static func unmarshalSignature(signatureData: Data) -> SECP256K1.UnmarshaledSignature? {
-        if signatureData.count != 65 { return nil }
-        let bytes = signatureData.bytes
-        let r = Array(bytes[0..<32])
-        let s = Array(bytes[32..<64])
-        return SECP256K1.UnmarshaledSignature(v: bytes[64], r: Data(r), s: Data(s))
+        guard signatureData.count == 65 else { return nil }
+        let rSlice = signatureData.prefix(32)
+        let sSlice = signatureData.dropFirst(32).prefix(32)
+        let v = signatureData[64]
+        return SECP256K1.UnmarshaledSignature(v: v, r: Data(rSlice), s: Data(sSlice))
     }
 
     /// Marshals the V, R and S signature parameters into a 65 byte recoverable EC signature.

--- a/Sources/web3swift/HookedFunctions/Web3+BrowserFunctions.swift
+++ b/Sources/web3swift/HookedFunctions/Web3+BrowserFunctions.swift
@@ -53,8 +53,8 @@ extension Web3.BrowserFunctions {
 
     public func personalECRecover(_ personalMessage: Data, signature: Data) -> String? {
         if signature.count != 65 { return nil }
-        let rData = signature[0..<32].bytes
-        let sData = signature[32..<64].bytes
+        let rData = Array(signature.prefix(32))
+        let sData = Array(signature.dropFirst(32).prefix(32))
         var vData = signature[64]
         if vData >= 27 && vData <= 30 {
             vData -= 27


### PR DESCRIPTION


## **Summary of Changes**

In Swift 6.2 (6.2.0.19.9), Data.bytes now returns a RawSpan not a [UInt8].

- Replaced `.bytes` calls with `Array(dataSlice)` where `[UInt8]` is required.
- No functional changes to APIs — this is a compatibility fix for Swift 6.2.

Fixes #892 

## **Test Data or Screenshots**
All tests passed
<img width="418" height="321" alt="Screenshot 2025-08-28 at 14 14 39" src="https://github.com/user-attachments/assets/5b38d63e-3536-4ada-93b5-82d12f32e532" />


###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
