### PR TITLE
Update secp256k1 package URL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,16 +14,24 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/attaswift/BigInt.git", .upToNextMinor(from: "5.4.0")),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.5.1"),
-        .package(name: "secp256k1", url: "https://github.com/GigaBitcoin/secp256k1.swift", .upToNextMinor(from: "0.10.0"))
+        .package(url: "https://github.com/21-DOT-DEV/swift-secp256k1.git", .upToNextMinor(from: "0.10.0"))
     ],
     targets: [
         .target(
             name: "Web3Core",
-            dependencies: ["BigInt", "secp256k1", "CryptoSwift"]
+            dependencies: [
+                "BigInt",
+                "CryptoSwift",
+                .product(name: "secp256k1", package: "swift-secp256k1")
+            ]
         ),
         .target(
             name: "web3swift",
-            dependencies: ["Web3Core", "BigInt", "secp256k1"],
+            dependencies: [
+                "Web3Core",
+                "BigInt",
+                .product(name: "secp256k1", package: "swift-secp256k1")
+            ],
             resources: [
                 .copy("./Browser/browser.js"),
                 .copy("./Browser/browser.min.js"),


### PR DESCRIPTION
## **Summary of Changes**

Update the secp256k1 dependency GitHub URL because the repository was moved.

Don't use deprecated `.package(name: "secp256k1", ...)` aliasing syntax.

## **Test Data or Screenshots**

<img width="428" height="61" alt="Screenshot 2026-01-15 at 13 29 33" src="https://github.com/user-attachments/assets/7d6f7abd-b59e-4f69-b2fb-09413fc2e305" />
